### PR TITLE
Fixed typo in example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -179,7 +179,7 @@ $(document).ready(function()
     $("#colorPicker3").tinycolorpicker();
     var picker = $('#colorPicker3').data("plugin_tinycolorpicker");
 
-    picker.setColor("#FG45CC");
+    picker.setColor("#FF45CC");
 });
                     </code></pre>
             </section>


### PR DESCRIPTION
The code in one of the examples didn't work because it contains an invalid color.