### PR TITLE
Fix mouse does not work on touch screen

### DIFF
--- a/lib/jquery.tinycolorpicker.js
+++ b/lib/jquery.tinycolorpicker.js
@@ -131,42 +131,41 @@
          * @private
          */
         function _setEvents() {
-            var eventType = touchEvents ? "touchstart" : "mousedown";
+            var eventTypes = touchEvents ? "touchstart mousedown" : "mousedown";
 
             if(hasCanvas) {
-                $color.bind(eventType, function(event) {
+                $color.bind(eventTypes, function (event) {
                     event.preventDefault();
                     event.stopPropagation();
 
                     $track.toggle();
 
-                    $(document).bind("mousedown.colorpicker", function(event) {
+                    $(document).bind("mousedown.colorpicker", function (event) {
                         $(document).unbind(".colorpicker");
 
                         self.close();
                     });
                 });
 
-                if(!touchEvents) {
-                    $canvas.mousedown(function(event) {
-                        mouseIsDown = true;
+                $canvas.mousedown(function(event) {
+                    mouseIsDown = true;
 
-                        _getColorCanvas(event);
+                    _getColorCanvas(event);
 
-                        $(document).bind("mouseup.colorpicker", function(event) {
-                            $(document).unbind(".colorpicker");
+                    $(document).bind("mouseup.colorpicker", function(event) {
+                        $(document).unbind(".colorpicker");
 
-                            self.close();
-
-                            return false;
-                        });
+                        self.close();
 
                         return false;
                     });
 
-                    $canvas.mousemove(_getColorCanvas);
-                }
-                else {
+                    return false;
+                });
+
+                $canvas.mousemove(_getColorCanvas);
+
+                if(touchEvents) {
                     $canvas.bind("touchstart", function(event) {
                         mouseIsDown = true;
 

--- a/lib/jquery.tinycolorpicker.js
+++ b/lib/jquery.tinycolorpicker.js
@@ -134,13 +134,13 @@
             var eventTypes = touchEvents ? "touchstart mousedown" : "mousedown";
 
             if(hasCanvas) {
-                $color.bind(eventTypes, function (event) {
+                $color.bind(eventTypes, function(event) {
                     event.preventDefault();
                     event.stopPropagation();
 
                     $track.toggle();
 
-                    $(document).bind("mousedown.colorpicker", function (event) {
+                    $(document).bind("mousedown.colorpicker", function(event) {
                         $(document).unbind(".colorpicker");
 
                         self.close();

--- a/lib/tinycolorpicker.js
+++ b/lib/tinycolorpicker.js
@@ -125,10 +125,8 @@
          * @private
          */
         function _setEvents() {
-            var eventType = touchEvents ? "touchstart" : "mousedown";
-
             if(hasCanvas) {
-                $color["on" + eventType] = function(event) {
+                $color["ontouchstart"] = $color["onmousedown"] = function(event) {
                     event.preventDefault();
                     event.stopPropagation();
 
@@ -141,27 +139,26 @@
                     };
                 };
 
-                if(!touchEvents) {
-                    $canvas.onmousedown = function(event) {
-                        event.preventDefault();
-                        event.stopPropagation();
+                $canvas.onmousedown = function(event) {
+                    event.preventDefault();
+                    event.stopPropagation();
 
-                        mouseIsDown = true;
+                    mouseIsDown = true;
 
-                        _getColorCanvas(event);
+                    _getColorCanvas(event);
 
-                        document.onmouseup = function(event) {
-                            document.onmouseup = null;
+                    document.onmouseup = function(event) {
+                        document.onmouseup = null;
 
-                            self.close();
+                        self.close();
 
-                            return false;
-                        };
+                        return false;
                     };
+                };
 
-                    $canvas.onmousemove = _getColorCanvas;
-                }
-                else {
+                $canvas.onmousemove = _getColorCanvas;
+
+                if(touchEvents) {
                     $canvas.ontouchstart = function(event) {
                         mouseIsDown = true;
 


### PR DESCRIPTION
Fixes issue https://github.com/wieringen/tinycolorpicker/issues/6

Also added mouse support when a touch screen is detected, since a lot of new laptops feature both a mouse and touch screen. 
